### PR TITLE
Escape regex special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function containsPath(fp, segment) {
 
 function normalize(str) {
   str = path.normalize(str);
+  str = str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
   return str.split(/[\\\/]+/);
 }
 


### PR DESCRIPTION
Escape regex special characters so that paths like '*_/_' will not crash the regex.
